### PR TITLE
feat: Docker image pipeline

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - "master"
+      - main
     tags:
       - "v*"
   pull_request:
     branches:
-      - "master"
+      - main
 
 jobs:
   release-continer-image:

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -23,13 +23,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
+      - name: Set up QEMU (v2.2.0)
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx (v2.9.1)
         uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.12.0
 
-      - name: Login to GHCR
+      - name: Login to GHCR (v2.2.0)
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
@@ -37,7 +40,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
+      - name: Docker meta (v4.6.0)
         id: docker-meta
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
@@ -49,7 +52,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build ARM64/AMD64 Image and push to ECR (on main)
+      - name: Build ARM64/AMD64 Image and push to GHCR (v4.1.1)
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: .

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -1,0 +1,59 @@
+name: Image Release
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  release-continer-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
+
+      - name: Login to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker-meta
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build ARM64/AMD64 Image and push to ECR (on main)
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}


### PR DESCRIPTION
Adds a GitHub Actions Workflow to build and publish containers to ghcr.io for your repository.

Images will be built for:
- All pushes to `main`
- All git tags starting with `v`

Both ARM64 and AMD64 images are produced.